### PR TITLE
Respect user specified widget text rule

### DIFF
--- a/assets/styles/components/_widgets.scss
+++ b/assets/styles/components/_widgets.scss
@@ -125,7 +125,6 @@
   &.widget_text {
 
     img {
-      width: 100%;
       height: 100%;
     }
   }


### PR DESCRIPTION
Applies to issue #3:
This CSS rule is not respecting what the user specified. It should be removed:
.widget.widget-text img, .widget.widget_text img { width: 100%; }