### PR TITLE
Fix text not wrapping around floated images

### DIFF
--- a/assets/styles/layouts/_posts.scss
+++ b/assets/styles/layouts/_posts.scss
@@ -69,10 +69,6 @@ main > article {
     .summary {
       word-break: break-all;
       overflow: hidden;
-
-      p {
-
-      }
     }
   }
 


### PR DESCRIPTION
Realtes to this in issue #3:
Because of this CSS, text in paragraphs does not wrap around floated images. You don't need this rule.
main > article .inner-entry .summary p { overflow: hidden; }